### PR TITLE
Added email from Auth0 management API

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -46,8 +46,7 @@ def generate_certificate(request, context):
         "score_percentage": result["percentage"],
         "score_absolute": result["points_scored"],
         "score_maximum": result["points_available"],
-        "date": int(result["time_finished"]),
-        "email": result["cm_user_id"]
+        "date": int(result["time_finished"])
     }
 
     if not result["passed"]:

--- a/handler.py
+++ b/handler.py
@@ -3,12 +3,16 @@ import hmac
 import hashlib
 import base64
 import os
+import boto3
 
 import lib.certificate as certificate
 import lib.neo4j_accounts as accts 
 
 from lib.encryption import decrypt_value
 
+from string import Template
+
+EMAIL_TEMPLATES_BUCKET = "training-certificate-emails.neo4j.com"
 
 def get_email_lambda(request, context):
     json_payload = json.loads(request["body"])
@@ -42,7 +46,8 @@ def generate_certificate(request, context):
         "score_percentage": result["percentage"],
         "score_absolute": result["points_scored"],
         "score_maximum": result["points_available"],
-        "date": int(result["time_finished"])
+        "date": int(result["time_finished"]),
+        "email": result["cm_user_id"]
     }
 
     if not result["passed"]:
@@ -53,4 +58,58 @@ def generate_certificate(request, context):
         certificate_path = certificate.generate(event)
         print("Certificate:", certificate_path)
 
+        context_parts = context.invoked_function_arn.split(':')
+        topic_name = "CertificatesToEmail"
+        topic_arn = "arn:aws:sns:{region}:{account_id}:{topic}".format(region=context_parts[3], account_id=context_parts[4], topic=topic_name)
+
+        sns = boto3.client('sns')
+        event["certificate"] = certificate_path
+        sns.publish(TopicArn= topic_arn, Message= json.dumps(event))
+
     return {"statusCode": 200, "body": certificate_path, "headers": {}}
+
+
+def send_email(event, context):
+    print(event)
+
+    s3 = boto3.client('s3')
+    response = s3.get_object(Bucket=EMAIL_TEMPLATES_BUCKET,Key="%s.txt" % ('email'))
+    templatePlainText = response['Body'].read().decode("utf-8")
+
+    response = s3.get_object(Bucket=EMAIL_TEMPLATES_BUCKET,Key="%s.html" % ('email'))
+    templateHtml = response['Body'].read().decode("utf-8")
+
+    templateObj = Template(templatePlainText)
+    templateHtmlObj = Template(templateHtml)
+
+    for record in event["Records"]:
+        message = json.loads(record["Sns"]["Message"])
+
+        name = message["name"]
+        # email = message["email"]
+        email = "m.h.needham@gmail.com"
+        certificate_path = message["certificate"]
+
+        email_client = boto3.client('ses')
+
+        bodyPlainText = templateObj.substitute(name=name, certificate=certificate_path)
+        bodyHtml = templateHtmlObj.substitute(name=name, certificate=certificate_path)
+
+
+        response = email_client.send_email(
+            Source = 'Neo4j DevRel <devrel+certification@neo4j.com>',
+            SourceArn = 'arn:aws:ses:us-east-1:128916679330:identity/neo4j.com',
+            Destination = {
+                'ToAddresses': [ email ]
+            },
+            Message = {
+                'Subject': { 'Data': '=?UTF-8?Q?=F0=9F=98=A2?= Your Neo4j Certification' },
+                'Body': {
+                    'Text':
+                        { 'Data': bodyPlainText },
+                    'Html':
+                        { 'Data': bodyHtml },
+                }
+            }
+        )
+        print(response)

--- a/lib/neo4j_accounts.py
+++ b/lib/neo4j_accounts.py
@@ -1,0 +1,54 @@
+import json
+import hmac
+import hashlib
+import base64
+import os
+import boto3
+import requests
+
+def get_auth0_management_token():
+    AUTH0_CREDS = boto3.client('kms').decrypt(CiphertextBlob=base64.b64decode(os.environ["AUTH0_CREDS"]))['Plaintext']
+
+    authci = json.loads(AUTH0_CREDS)
+    clientSecret = authci['client_secret']
+    clientId = authci['client_id']
+    audience = authci['audience']
+    tokenEndpoint = authci['token_endpoint']
+    apiEndpoint = authci['api_endpoint']
+
+    payload_obj = {
+      "grant_type": "client_credentials",
+      "client_id": clientId,
+      "client_secret": clientSecret,
+      "audience": audience
+    }
+    r = requests.post(tokenEndpoint,
+              headers={"Content-type": "application/json"},
+              data = json.dumps(payload_obj))
+    data = r.content
+    data_obj = json.loads(data.decode("utf-8"))
+    return_obj = {
+      "access_token": data_obj["access_token"],
+      "api_endpoint": apiEndpoint
+    }
+    return return_obj
+
+def get_email_address(user):
+    global LOGGING_LEVEL
+
+    apiInfo = get_auth0_management_token()
+
+    try:
+      r = requests.get(
+            '%susers/%s' % (apiInfo['api_endpoint'], user),
+            headers={"Authorization": "bearer %s" % apiInfo['access_token'] })
+
+      jsonProfile = r.text
+      profile = json.loads(jsonProfile)
+      if 'email' in profile:
+        return profile['email']
+      else:
+        return False
+    except:
+      return False
+

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,16 @@ frameworkVersion: ">=1.2.0 <2.0.0"
 
 custom:
   stage: "${opt:stage, self:provider.stage}"
-  kmsKeyArn: ${file(env.yml):${self:custom.stage}.KEY_ARN}  
+  kmsKeyArn: ${file(env.yml):${self:custom.stage}.KEY_ARN}
+  CertificatesTopic:
+    Fn::Join:
+      - ":"
+      - - arn
+        - aws
+        - sns
+        - Ref: AWS::Region
+        - Ref: AWS::AccountId
+        - CertificatesToEmail
 
 provider:
   name: aws
@@ -22,6 +31,16 @@ provider:
         - KMS:Decrypt
       Resource:
         - ${self:custom.kmsKeyArn}
+    - Effect: 'Allow'
+      Action:
+        - "sns:Publish"
+      Resource:
+        - ${self:custom.CertificatesTopic}
+    - Effect: Allow
+      Action:
+        - ses:SendEmail
+        - ses:SendRawEmail
+      Resource: "arn:aws:ses:us-east-1:128916679330:identity/neo4j.com"
 
 plugins:
   - serverless-python-requirements
@@ -33,6 +52,14 @@ functions:
       role: 'arn:aws:iam::715633473519:role/lambda_graphacademy'
       events:
         - http: POST generateCertificate
+  send-email:
+      name: SendEmail
+      handler: handler.send_email
+      role: 'arn:aws:iam::715633473519:role/lambda_graphacademy'
+      events:
+        - sns:
+            topicName: CertificatesToEmail
+            displayName: Topic to email certificates
   get-email:
       name: Auth0GetEmailFromUid
       handler: handler.get_email_lambda
@@ -42,4 +69,5 @@ functions:
 
 package:
   exclude:
+    - node_modules/**
     - a/**

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,16 +4,7 @@ frameworkVersion: ">=1.2.0 <2.0.0"
 
 custom:
   stage: "${opt:stage, self:provider.stage}"
-  kmsKeyArn: ${file(env.yml):${self:custom.stage}.KEY_ARN}
-  CertificatesTopic:
-    Fn::Join:
-      - ":"
-      - - arn
-        - aws
-        - sns
-        - Ref: AWS::Region
-        - Ref: AWS::AccountId
-        - CertificatesToEmail
+  kmsKeyArn: ${file(env.yml):${self:custom.stage}.KEY_ARN}  
 
 provider:
   name: aws
@@ -31,16 +22,6 @@ provider:
         - KMS:Decrypt
       Resource:
         - ${self:custom.kmsKeyArn}
-    - Effect: 'Allow'
-      Action:
-        - "sns:Publish"
-      Resource:
-        - ${self:custom.CertificatesTopic}
-    - Effect: Allow
-      Action:
-        - ses:SendEmail
-        - ses:SendRawEmail
-      Resource: "arn:aws:ses:us-east-1:128916679330:identity/neo4j.com"
 
 plugins:
   - serverless-python-requirements
@@ -49,17 +30,16 @@ functions:
   generate-certificate:
       name: GenerateCertificate
       handler: handler.generate_certificate
+      role: 'arn:aws:iam::715633473519:role/lambda_graphacademy'
       events:
         - http: POST generateCertificate
-  send-email:
-      name: SendEmail
-      handler: handler.send_email
+  get-email:
+      name: Auth0GetEmailFromUid
+      handler: handler.get_email_lambda
+      role: 'arn:aws:iam::715633473519:role/lambda_graphacademy'
       events:
-        - sns:
-            topicName: CertificatesToEmail
-            displayName: Topic to email certificates
+        - http: POST Auth0GetEmailFromUid
 
 package:
   exclude:
-    - node_modules/**
     - a/**


### PR DESCRIPTION
Added neo4j_accounts lib which will retrieve the e-mail address from the Auth0 management API.

It does add a get_email_lambda function, which we might want to restrict.  

Requires a AUTH0_CREDS object in an ENV variable with the following:
    clientSecret = authci['client_secret']
    clientId = authci['client_id']
    audience = authci['audience']
    tokenEndpoint = authci['token_endpoint']
    apiEndpoint = authci['api_endpoint']

Here's an encrypted version of AUTH0_CREDS for env.yml:

AUTH0_CREDS: AQECAHiKkZk3iOHTLUzTG5MCv+NbkbwNJelCfETVV6O/9dEUhQAAAY8wggGLBgkqhkiG9w0BBwagggF8MIIBeAIBADCCAXEGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM6c83rCCYjUTY2s6+AgEQgIIBQsbZdpg0+QfTS9QB6AKEU9XvDuvRXKWpEef+Dujy9R44A5o+XiX9ozmoECeRB2rkqHjevzbiBUqiTWJ4NGDiQykCMJFc4xoUblEGmMZCdaHeuahEwQtwej/OEN5rW7AD/3glZSyb81U4OgshieyU+YwJwGh2akfZjpE9h+IYcA5EcTa8mavbR3NgPJoSkNFVrY6V+w+BkIyiy1pCfQPGs40iqJobh0Hrzimbj/3jJ4Ky9sHyCphWa1tUdaS5BT2aoxaJYz4AHLExd77Jz5TVZFW9cxFYlsxiFQ0P+4JMG2VvCTUejks9gULgpM8la+Or1GKC66zalxeduLbp7ysC8o3VxGkhKcAIYPDieIMRkcytf7tjkNH6ovn2wjhUblBFlQhPrdgg+p76HWA1qyhvvJ03dhDwwkjXdkVb5df/N65mbGc=
